### PR TITLE
feat: Add FAQController with CRUD operations

### DIFF
--- a/InsurTechSolution/InsurTech.APIs/Controllers/FAQController.cs
+++ b/InsurTechSolution/InsurTech.APIs/Controllers/FAQController.cs
@@ -1,0 +1,105 @@
+﻿using AutoMapper;
+using InsurTech.APIs.DTOs.FAQDTOs;
+using InsurTech.Core;
+using InsurTech.Core.Entities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace InsurTech.APIs.Controllers
+{
+    [Route("api/FAQs")]
+    [ApiController]
+    public class FAQController : ControllerBase
+    {
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly IMapper _mapper;
+
+        public FAQController(IUnitOfWork unitOfWork, IMapper mapper)
+        {
+            _unitOfWork = unitOfWork;
+            _mapper = mapper;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetFAQs()
+        {
+            var faqs = await _unitOfWork.Repository<FAQ>().GetAllAsync();
+
+            var faqDtos = _mapper.Map<List<FAQDTO>>(faqs);
+
+            return Ok(faqDtos);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetFAQ(int id)
+        {
+            var faq = await _unitOfWork.Repository<FAQ>().GetByIdAsync(id);
+            if (faq == null)
+            {
+                return NotFound();
+            }
+
+            var faqDto = _mapper.Map<FAQDTO>(faq);
+
+            return Ok(faqDto);
+        }
+
+        [HttpPost]
+        [Authorize(Roles = Roles.Admin)]
+        public async Task<IActionResult> CreateFAQ([FromBody] CreateFAQInput createFAQInput)
+        {
+            var faq = _mapper.Map<FAQ>(createFAQInput);
+
+            faq.UserId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+
+            await _unitOfWork.Repository<FAQ>().AddAsync(faq);
+
+            await _unitOfWork.CompleteAsync();
+
+            var faqDto = _mapper.Map<FAQDTO>(faq);
+
+            return CreatedAtAction(nameof(GetFAQ), new { id = faq.Id }, faqDto);
+        }
+        [HttpPut("{id}")]
+        [Authorize(Roles = Roles.Admin)]
+
+        public async Task<IActionResult> UpdateFAQ([FromRoute] int id, [FromBody] CreateFAQInput createFAQInput)
+        {
+            var faq = await _unitOfWork.Repository<FAQ>().GetByIdAsync(id);
+
+            if (faq == null)
+            { return NotFound(); }
+
+            _mapper.Map<CreateFAQInput, FAQ>(createFAQInput, faq);
+
+            await _unitOfWork.CompleteAsync();
+
+            var faqDto = _mapper.Map<FAQDTO>(faq);
+
+            return Ok(faqDto);
+        }
+
+        [HttpDelete("{id}")]
+        [Authorize(Roles = Roles.Admin)]
+
+        public async Task<IActionResult> DeleteFAQ(int id)
+        {
+            var faq = await _unitOfWork.Repository<FAQ>().GetByIdAsync(id);
+
+            if (faq == null)
+            { return NotFound(); }
+
+
+            await _unitOfWork.Repository<FAQ>().Delete(faq);
+
+            await _unitOfWork.CompleteAsync();
+
+
+            return Ok("FAQ deleted successfully.");
+
+        }
+
+    }
+}

--- a/InsurTechSolution/InsurTech.APIs/DTOs/FAQDTOs/CreateFAQInput.cs
+++ b/InsurTechSolution/InsurTech.APIs/DTOs/FAQDTOs/CreateFAQInput.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace InsurTech.APIs.DTOs.FAQDTOs
+{
+    public class CreateFAQInput
+    {
+        [Required]
+        [MinLength(3, ErrorMessage = "Answer must be at least 3 characters")]
+        public string Answer { get; set; }
+        [Required]
+        [MinLength(3, ErrorMessage = "Body must be at least 3 characters")]
+        public string Body { get; set; }
+    }
+}

--- a/InsurTechSolution/InsurTech.APIs/DTOs/FAQDTOs/FAQDTO.cs
+++ b/InsurTechSolution/InsurTech.APIs/DTOs/FAQDTOs/FAQDTO.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace InsurTech.APIs.DTOs.FAQDTOs
+{
+    public class FAQDTO
+    {
+        [Required]
+        public int Id { get; set; }
+        [Required]
+        [MinLength(3,ErrorMessage = "Answer must be at least 3 characters")]
+        public string Answer { get; set; }
+        [Required]
+        [MinLength(3, ErrorMessage = "Body must be at least 3 characters")]
+        public string Body { get; set; }
+
+        [Required]
+        public string UserId { get; set; }
+
+
+    }
+}

--- a/InsurTechSolution/InsurTech.APIs/DTOs/FAQDTOs/FAQMapProfile.cs
+++ b/InsurTechSolution/InsurTech.APIs/DTOs/FAQDTOs/FAQMapProfile.cs
@@ -1,0 +1,15 @@
+﻿using AutoMapper;
+using InsurTech.Core.Entities;
+
+namespace InsurTech.APIs.DTOs.FAQDTOs
+{
+    public class FAQMapProfile : Profile
+    {
+        public FAQMapProfile() {
+
+            CreateMap<CreateFAQInput, FAQ>();
+            CreateMap<FAQ,FAQDTO>().ReverseMap();
+
+        }
+    }
+}

--- a/InsurTechSolution/InsurTech.APIs/InsurTech.APIs.csproj
+++ b/InsurTechSolution/InsurTech.APIs/InsurTech.APIs.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>


### PR DESCRIPTION
The code changes include the addition of a new controller, FAQController, which handles CRUD operations for FAQs. It also includes the necessary DTOs and mapping profiles for FAQs. This commit adds the controller, along with the necessary actions for getting all FAQs, getting a specific FAQ by ID, creating a new FAQ, updating an existing FAQ, and deleting an FAQ. The controller is protected with authorization, allowing only users with the "Admin" role to access the actions.